### PR TITLE
Fixed error presented when used as a script in browser 

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ exports.searchTorrentz2 = function(searchStr){
 
       if (err){
         deferred.reject(err);
+        return false;
       }
 
         var $ = cheerio.load(html);

--- a/app.js
+++ b/app.js
@@ -13,7 +13,8 @@ exports.searchTorrentz2 = function(searchStr){
     const deferred = Q.defer();
     const option = {url: `https://torrentz2.eu/search?f=${searchStr}`,
                     headers:{
-                      'Access-Control-Allow-Origin':'*'
+                      'Access-Control-Allow-Origin':'*',
+                      "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
                     }
                   };
     request(option, function (err, resp, html) {


### PR DESCRIPTION
The added header allows this library to be used as an standalone script in a pure HTML (no framework used) project, for example being used with require.js or CommonJS.